### PR TITLE
Add Public Holiday Service and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
@@ -1,11 +1,20 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
-
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
@@ -23,8 +23,17 @@ public class PublicHolidayQueryService {
     public static final String ENDPOINT = "https://date.nager.at/api/v2/publicholidays/{year}/{countryCode}";
 
     public String getJSON(String year, String countryCode) throws HttpClientErrorException {
+        log.info("year={}, countryCode={}", year, countryCode);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
         Map<String, String> uriVariables = Map.of("year", year, "countryCode", countryCode);
-        return "";
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
     }
 
    

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
@@ -20,9 +20,10 @@ public class PublicHolidayQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://date.nager.at/api/v2/publicholidays/{year}/{countryCode}";
 
     public String getJSON(String year, String countryCode) throws HttpClientErrorException {
+        Map<String, String> uriVariables = Map.of("year", year, "countryCode", countryCode);
         return "";
     }
 

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(PublicHolidayQueryService.class)
+public class PublicHolidayQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private PublicHolidayQueryService publicHolidayQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String year = "2023";
+        String countryCode = "us";
+        String expectedURL = PublicHolidayQueryService.ENDPOINT.replace("{year}", year).replace("{countryCode}", countryCode);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = publicHolidayQueryService.getJSON(year, countryCode);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add a service that wraps the Public Holiday API from
https://date.nager.at/api/v2/publicholidays/{year}/{countryCode}

Closes #10 